### PR TITLE
Subscribe a client to the events channel on ws connection

### DIFF
--- a/app/src/Interfaces/Centrifugo/ConnectService.php
+++ b/app/src/Interfaces/Centrifugo/ConnectService.php
@@ -19,7 +19,8 @@ class ConnectService implements ServiceInterface
         try {
             $request->respond(
                 new ConnectResponse(
-                    user: (string) $request->getAttribute('user_id')
+                    user: (string) $request->getAttribute('user_id'),
+                    channels: ['events'],
                 )
             );
         } catch (\Throwable $e) {


### PR DESCRIPTION
This PR allows a client don't use channel subscription on client side. Server will automatically subscribe a client on `events` channel after conenction.

Use the following JS code to listen events

```js
const centrifuge = new Centrifuge('ws://127.0.0.1:8081/connection/websocket');

centrifuge.connect();

centrifuge.on('publication', ctx => {
      if (
          ctx.channel !== 'events' ||
      ) {
        return;
      }

      // handle payload 
     console.log(ctx.data)
})
```